### PR TITLE
Same kafka group id for eservice-consumer, in local and in dev

### DIFF
--- a/packages/eservice-event-consumer/.env
+++ b/packages/eservice-event-consumer/.env
@@ -4,10 +4,9 @@
 # KAFKA_DISABLE_AWS_IAM_AUTH="true"
 # KAFKA_TOPIC="eservice"
 
-
-# Dev 
-KAFKA_CLIENT_ID="signalhub-dev-catalog-event-consumer-key"
-KAFKA_GROUP_ID="signalhub-dev-catalog-event-consumer"
+# Dev
+KAFKA_CLIENT_ID="signalhub-dev-eservice-event-consumer-key"
+KAFKA_GROUP_ID="signalhub-dev-eservice-event-consumer"
 KAFKA_BROKERS="b-2.iam.interopplatformevents.2doelu.c2.kafka.eu-south-1.amazonaws.com:14002,b-1.iam.interopplatformevents.2doelu.c2.kafka.eu-south-1.amazonaws.com:14001,b-3.iam.interopplatformevents.2doelu.c2.kafka.eu-south-1.amazonaws.com:14003"
 KAFKA_TOPIC="outbound.dev_catalog.events"
 TOPIC_STARTING_OFFSET="earliest"
@@ -17,7 +16,7 @@ SH_DB_HOST="localhost"
 SH_DB_NAME="signal-hub"
 SH_DB_USERNAME="postgres"
 SH_DB_PASSWORD="postgres"
-SH_DB_PORT=5432 
+SH_DB_PORT=5432
 SH_DB_USE_SSL="false"
 
 LOG_LEVEL=debug


### PR DESCRIPTION
See https://github.com/pagopa/interop-signalhub-deployment/pull/32