### PR TITLE
NTRP-320: change logging level message (persister-service)

### DIFF
--- a/packages/signal-persister/src/services/storeSignal.service.ts
+++ b/packages/signal-persister/src/services/storeSignal.service.ts
@@ -28,7 +28,9 @@ export function storeSignalServiceBuilder(db: DB) {
 
         /* it means that signal is already present on db */
         if (signalRecordId !== null) {
-          logger.warn(`SignalId: ${signal.signalId} already exists`);
+          logger.warn(
+            `SignalId: ${signal.signalId} already exists (NotRecoverableMessage)`
+          );
           throw notRecoverableMessageError(
             "duplicateSignal",
             signal,
@@ -38,11 +40,11 @@ export function storeSignalServiceBuilder(db: DB) {
           await signalRepositoryInstance.insertSignal(signal);
         }
       } catch (error) {
-        logger.error(error);
-
         if (error instanceof NotRecoverableMessageError) {
           throw error;
         }
+
+        logger.error(error);
 
         throw recoverableMessageError(
           "dbConnection",


### PR DESCRIPTION
This PR update the kind of message returned when a signal is already available on DB (thus, it shouldn't saved on db again). Instead of logging this message as "error" it will be print as "warn" message.